### PR TITLE
Change org.clojure/clojure to "provided"

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/dakrone/tigris"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]]
+  :dependencies [[org.clojure/clojure "1.5.1" :scope "provided"]
   :profiles {:dev {:dependencies [[cheshire "5.1.1"]]}}
   :source-paths ["src/clj"]
   :java-source-paths ["src/java"])


### PR DESCRIPTION
Hello! Just a simple change in order for tigris not to import clojure if used as transitive dependency (e.g.: `cheshire`). I hope you don't mind! :smile: 