### PR TITLE
Remove explicit Clojure dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,8 @@
   :url "https://github.com/dakrone/tigris"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]]
-  :profiles {:dev {:dependencies [[cheshire "5.1.1"]]}}
+  :dependencies []
+  :profiles {:dev {:dependencies [[cheshire "5.1.1"]
+                                  [org.clojure/clojure "1.8.0"]]}}
   :source-paths ["src/clj"]
   :java-source-paths ["src/java"])


### PR DESCRIPTION
I noticed that Tigris has an explicit dependency on Clojure 1.5.1, which generates a classpath conflict warning when using it (or Cheshire) in another library:

```
Classpath conflict: org.clojure/clojure version 1.8.0 already loaded, NOT loading version 1.5.1
```

The fix is to remove the org.clojure/clojure dependency, so that we're not depending on any particular version of Clojure.

This PR removes the Clojure dependency and adds a development dependency on Clojure 1.8.0. `lein test` tests pass with this setup.